### PR TITLE
Add troubleshooting for FX3U bootloader upload

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@
 - Select the correct serial port
 - Click on ***Install Bootloader***
 - Click ***Upload*** button to start installing the bootloader.
-- If the upload is succesfull, the `RUN` led will blink rapidly to indicate it is in bootloader mode.
+- If the upload is succesful, the `RUN` led will blink rapidly to indicate it is in bootloader mode.
 
 #### Normal Usage
 - Select the generated openplc code using the ***Browse*** button.
@@ -38,3 +38,21 @@
 - Set the PLC `RUN` switch to `STOP` position.
 - Click ***Upload*** button to start uploading.
 - Set the PLC `RUN` switch to `RUN` to start the PLC.
+
+## FX3U PLC Clone troubleshooting
+
+### Upload of bootloader does not work initially
+
+- Likely the flash memory is locked-out by the PLC vendor.
+- To unlock the memory:
+  - Download and install [STM32CubeProg](https://www.st.com/en/development-tools/stm32cubeprog.html)
+  - Follow the steps in [Enable DFU mode on PLC](#enable-dfu-mode-on-plc) to enable the bootloader
+  - Run the unprotect sequence (example uses Windows and COM8 serial port):
+    - `"C:\Program Files\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=COM8 br=57600 -rdu`
+    - NOTE: The `-rdu` command at the end is the command to remove read-out protection
+  - The unprotect sequence will likely show error messages. However, as long as `Activating device: OK` is seen, and multiple retry attempts are shown in the log, the sequence will have likely worked. You can tell by the fact that the next steps (and eventually, the bootloader upload) will now succeed.
+  - Follow **again** the steps in [Enable DFU mode on PLC](#enable-dfu-mode-on-plc) to enable the bootloader
+  - Perform a mass-erase of the MCU (example uses Windows and COM8 serial port):
+    - `"C:\Program Files\STMicroelectronics\STM32Cube\STM32CubeProgrammer\bin\STM32_Programmer_CLI.exe" -c port=COM8 br=57600 -e all`
+    - NOTE: The `-e all` command at the end is the command to mass-erase the entire MCU.
+- Now you can start over at the beginning of the sequence: [Enable DFU mode on PLC](#enable-dfu-mode-on-plc), then [Install Bootloader](#install-bootloader).


### PR DESCRIPTION
- Upload will fail unless the read-out protection is disabled. Procedure to fix is described here.
- Procedure is adapted from https://openplc.discussion.community/post/openplc-on-stm32-using-freertos-12393274?pid=1333129173
- Tested against a FX3U-MR14 clone